### PR TITLE
ExplicitStringVariableFixer - Fix for variable as an array key

### DIFF
--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -90,8 +90,9 @@ EOT
             ];
 
             $nextIndex = $index + 1;
+            $squareBracketCount = 0;
             while (!$this->isStringPartToken($tokens[$nextIndex])) {
-                if ($tokens[$nextIndex]->isGivenKind(T_VARIABLE)) {
+                if ($tokens[$nextIndex]->isGivenKind(T_VARIABLE) && 1 !== $squareBracketCount) {
                     $distinctVariableIndex = $nextIndex;
                     $variableTokens[$distinctVariableIndex] = [
                         'tokens' => [$nextIndex => $tokens[$nextIndex]],
@@ -101,6 +102,10 @@ EOT
                 } else {
                     $variableTokens[$distinctVariableIndex]['tokens'][$nextIndex] = $tokens[$nextIndex];
                     $variableTokens[$distinctVariableIndex]['lastVariableTokenIndex'] = $nextIndex;
+
+                    if ($tokens[$nextIndex]->equalsAny(['[', ']'])) {
+                        ++$squareBracketCount;
+                    }
                 }
 
                 ++$nextIndex;

--- a/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
@@ -126,6 +126,10 @@ EOF;
                 '<?php $a = "My name is $array[$foo] !";',
             ],
             [
+                '<?php $a = "My name is {$array[$foo]}[${bar}] !";',
+                '<?php $a = "My name is $array[$foo][$bar] !";',
+            ],
+            [
                 '<?php $a = "Closure not allowed ${closure}() text";',
                 '<?php $a = "Closure not allowed $closure() text";',
             ],


### PR DESCRIPTION
Reference: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4379